### PR TITLE
Set Word add-on to async mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,5 +77,5 @@ ChatGPT directly integrated into Google Docs 📑
 
 ![image](https://user-images.githubusercontent.com/67405604/205882403-1fee052b-1a40-45e0-838b-f0c9268611ed.png)
 
-10. Wait for your result! (Word may become temporarily unresponsive while waiting for the result)
+1.  Wait for your result! (Currently it is not recommended to ask ChatGPT again before current question is answered, otherwise all the answers can be mixed up. Keyboard input is disabled while waiting for the result, see issue #9.)
 

--- a/wordGPT/ask.bas
+++ b/wordGPT/ask.bas
@@ -27,26 +27,17 @@ Private Sub Ask()
     Dim selection As selection
     Set selection = Application.selection
     Dim selectedText As String
-    Dim rng As Word.Range
-    
+    Dim init_end, new_end As Integer
+
     selectedText = Replace(selection.text, ChrW$(13), "")
-    
+    init_end = CInt(selection.End)
+
     Dim req As Object
     Set req = CreateObject("WinHttp.WinHttpRequest.5.1")
 
-    req.Open "POST", "https://chatgpt-api.kesarx.repl.co/chat", False
+    req.Open "POST", "https://chatgpt-api.kesarx.repl.co/chat", True
     req.SetRequestHeader "Content-Type", "application/json"
-    
-    Dim f
-    Dim json As String
-    
-    Dim text As String
-    
-    text = selectedText
-
-    json = "{""message"": """ & text & """}"
-    
-    req.Send json
+    req.Send "{""message"": """ & selectedText & """}"
     
     req.WaitForResponse
     
@@ -58,7 +49,9 @@ Private Sub Ask()
 
     Dim result As String
     result = objWin.response_msg
-    
+
+    new_end = CInt(selection.End)
+    selection.Move Unit:=wdCharacter, Count:=init_end - new_end
     selection.Range.InsertAfter Chr(10) & result & Chr(10)
     
 End Sub


### PR DESCRIPTION
Currently the Word add-on is working in sync mode which makes Word temporarily unresponsive while waiting for the result. This PR turns it into async mode and the users can use Word as usual before ChatGPT responds. However, in async mode it still has an issue #9, keyboard input is disabled before a ChatGPT response is received. And as updated in README, working in async mode allows people to ask ChatGPT multiple times at the same time and thus it can mix up the answers, so it is recommended to only ask one question each time. Despite these issues, this PR should give the users a better experience in Word.